### PR TITLE
Strip line endings after reading the cookies.

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ keyfile = json.loads(keyfile)
 if os.path.exists(cookiefile_path):
     with open(cookiefile_path, encoding="utf8", mode='r') as cookiefile:
         cookies = cookiefile.read()
+        cookies = cookies.rstrip()
 else:
     print("No cookies.txt file was found, you won't be able to download subscription courses! You can ignore ignore this if you don't plan to download a course included in a subscription plan.")
 


### PR DESCRIPTION
This should help resolve the line endings issue, regardless of the OS that it is running on. It just removes the line endings from the read string, which should only be a single line anyway.