### PR TITLE
Skip Check for ffmpeg and shaka-packager if --skip-lectures flag is True

### DIFF
--- a/main.py
+++ b/main.py
@@ -1721,7 +1721,7 @@ def main():
         sys.exit(1)
 
     ffmpeg_ret_val = check_for_ffmpeg()
-    if not ffmpeg_ret_val:
+    if not ffmpeg_ret_val and not skip_lectures:
         logger.fatal("> FFMPEG is missing from your system or path!")
         sys.exit(1)
 

--- a/main.py
+++ b/main.py
@@ -1726,7 +1726,7 @@ def main():
         sys.exit(1)
 
     shaka_ret_val = check_for_shaka()
-    if not shaka_ret_val:
+    if not shaka_ret_val and not skip_lectures:
         logger.fatal("> Shaka Packager is missing from your system or path!")
         sys.exit(1)
 


### PR DESCRIPTION
I had a scenario where I wanted to download the assets only. To do that, I was using --skip-lectures flag as per the README, but I didn't have shaka-packager installed. Since only assets were required, I think we don't need to have shaka-packager installed in that scenario. Same thing with ffmpeg.

`python main.py -c <course url> --skip-lectures --download-assets`

Added condition which will bypass the ffmpeg and shaka-packager check in case we only want to download the assets.