### PR TITLE
Add en-dash (–) to shaka-packager replacement list

### DIFF
--- a/main.py
+++ b/main.py
@@ -1388,6 +1388,7 @@ def handle_segments(url, format_id, video_title, output_path, lecture_file_name,
         .replace("%", "")
         # commas cause problems with shaka-packager resulting in decryption failure
         .replace(",", "")
+        .replace("–", "-")
         .replace(".mp4", "")
     )
 


### PR DESCRIPTION
Modify code to add en-dash (–) to shaka-packager replacement list, as some Udemy videos use this symbol, and the process stops because shaka-packager won't recognize video names with this symbol.