### PR TITLE
fix for audio overrun during multiplexing

### DIFF
--- a/main.py
+++ b/main.py
@@ -1277,7 +1277,7 @@ def mux_process(video_title, video_filepath, audio_filepath, output_path):
                 transcode, video_filepath, audio_filepath, codec, h265_crf, h265_preset, video_title, output_path
             )
         else:
-            command = 'nice -n 7 ffmpeg -y -i "{}" -i "{}" -c:v copy -c:a copy -fflags +bitexact -map_metadata -1 -metadata title="{}" "{}"'.format(
+            command = 'nice -n 7 ffmpeg -y -i "{}" -i "{}" -c:v copy -c:a copy -fflags +bitexact -shortest -map_metadata -1 -metadata title="{}" "{}"'.format(
                 video_filepath, audio_filepath, video_title, output_path
             )
 


### PR DESCRIPTION
Added `-shortest` flag to force a cut at the end of the shortest stream during multiplexing. This resolves issue #215 on Linux. 

This PR only contains the patch for Linux since I was not able to test on Windows or with x265 encoding and the original bug report specifically mentioned Linux.