### PR TITLE
Remove image property; add container name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   udemy-downloader:
-    image: udemy-downloader:latest
+    container_name: udemy-downloader
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Due to local builds (the image does not exist on Docker Hub or any registry), if the `image` property is set, Docker will attempt to pull it. To avoid this behavior, the image property was removed.