### PR TITLE
Add roleplay support

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -31,6 +31,7 @@ class URLS:
     MY_COURSES = "https://{portal_name}.udemy.com/api-2.0/users/me/subscribed-courses?fields[course]=id,url,title,published_title&ordering=-last_accessed,-access_time&page=1&page_size=10000"
     COLLECTION = "https://{portal_name}.udemy.com/api-2.0/users/me/subscribed-courses-collections/?collection_has_courses=True&course_limit=20&fields[course]=last_accessed_time,title,published_title&fields[user_has_subscribed_courses_collection]=@all&page=1&page_size=1000"
     QUIZ = "https://{portal_name}.udemy.com/api-2.0/quizzes/{quiz_id}/assessments/?page_size=250&fields[assessment]=id,assessment_type,prompt,correct_response,section,question_plain,related_lectures"
+    ROLE_PLAY = "https://{portal_name}.udemy.com/course/{course_name}/learn/role-play/{role_play_id}/?udfrontends=true&cteMode=standalone"
     VISIT = "https://{portal_name}.udemy.com/api-2.0/visits/current/?fields%5Bvisit%5D=@default,visitor,country&locale=en_US"
     # URL form encoded, email
     CODE_GENERATION = "https://www.udemy.com/api-2.0/auth/code-generation/login/4.0/"

--- a/main.py
+++ b/main.py
@@ -1747,6 +1747,149 @@ def process_coding_assignment(quiz, lecture, chapter_dir):
             f.write(html)
 
 
+def process_role_play(udemy: Udemy, lecture, chapter_dir):
+    lecture_title = lecture.get("lecture_title")
+    lecture_index = lecture.get("lecture_index")
+    lecture_file_name = sanitize_filename(lecture_title + ".html")
+    lecture_path = os.path.join(chapter_dir, lecture_file_name)
+
+    logger.info(f"  > Processing role play {lecture_index}")
+
+    global portal_name
+    url = URLS.ROLE_PLAY.format(portal_name=portal_name, course_name="None", role_play_id=lecture.get("id"))
+    
+    # inject access_token cookie if there's bearer token
+    cookies_obj = None
+    if hasattr(udemy.session, "_session") and hasattr(udemy.session._session, "cookies"):
+        cookies_obj = udemy.session._session.cookies
+    elif hasattr(udemy.session, "cookies"):
+        cookies_obj = udemy.session.cookies
+        
+    bearer = udemy.bearer_token
+    if bearer and cookies_obj is not None:
+        if not cookies_obj.get("access_token" ):
+            cookies_obj.set("access_token", bearer, domain="www.udemy.com")
+
+    if hasattr(udemy.session, "_get"):
+        resp = udemy.session._get(url)
+    else:
+        resp = udemy.session.get(url)
+            
+    html_content = resp.text
+
+    # extract combined Next.js
+    combined_json = ""
+    matches = re.findall(r'__next_f.*?\.push\(\[(\d+),\s*("(?:[^"\\]|\\.)*")\]\)', html_content, re.DOTALL)
+    
+    for type_id, m in matches:
+        content_str = json.loads(m)
+        if isinstance(content_str, str):
+            combined_json += content_str
+
+    if not combined_json:
+        combined_json = html_content
+
+    # search for the role-play data obj
+    role_play_data = None
+
+    def find_rp(d):
+        if isinstance(d, dict):
+            if "scenario" in d and ("aiCharacter" in d or "learnerRole" in d or "meeting" in d):
+                return d
+            for v in d.values():
+                res = find_rp(v)
+                if res:
+                    return res
+        elif isinstance(d, list):
+            for item in d:
+                res = find_rp(item)
+                if res:
+                    return res
+        return None
+
+    for line in combined_json.split('\n'):
+        if not line.strip():
+            continue
+        parts = line.split(':', 1)
+        if len(parts) == 2:
+            try:
+                data = json.loads(parts[1])
+                found = find_rp(data)
+                if found:
+                    role_play_data = found
+                    break
+            except Exception:
+                pass
+
+    # edgecase handling as sometimes it references data
+    def resolve_refs(data):
+        if isinstance(data, dict):
+            for k in list(data.keys()):
+                data[k] = resolve_refs(data[k])
+        elif isinstance(data, list):
+            for i in range(len(data)):
+                data[i] = resolve_refs(data[i])
+        elif isinstance(data, str) and data.startswith('$') and len(data) > 1:
+            chunk_id = data[1:]
+            idx = combined_json.find(f"{chunk_id}:T")
+            if idx != -1:
+                comma_idx = combined_json.find(',', idx)
+                if comma_idx != -1:
+                    try:
+                        len_hex = combined_json[idx + len(chunk_id) + 2 : comma_idx]
+                        byte_len = int(len_hex, 16)
+                        start_idx =  comma_idx + 1
+                        encoded = combined_json.encode('utf-8')
+                        start_bytes = len(combined_json[:start_idx].encode('utf-8'))
+                        return encoded[start_bytes : start_bytes + byte_len].decode('utf-8')
+                    except Exception:
+                        pass
+            else:
+                idx = combined_json.find(f"\n{chunk_id}:\"")
+                if idx == -1 and combined_json.startswith(f"{chunk_id}:\""):
+                    idx = 0
+                else:
+                    idx += 1 if idx != -1 else 0
+                
+                if idx != 0 or combined_json.startswith(f"{chunk_id}:\""):
+                    end_idx = combined_json.find('\n', idx)
+                    if end_idx == -1: 
+                        end_idx = len(combined_json)
+                    try:
+                        return json.loads(combined_json[idx + len(chunk_id) + 1 : end_idx])
+                    except Exception:
+                        pass
+        return data
+
+    if not role_play_data:
+        logger.warning(f"  > Could not extract role play for {lecture_index}.")
+        return
+
+    role_play_data = resolve_refs(role_play_data)
+    
+    clean_data = {
+        "title": lecture_title,
+        "scenario": role_play_data.get("scenario", ""),
+        "learnerRole": role_play_data.get("learnerRole", ""),
+        "meeting": {
+            "title": role_play_data.get("meeting", {}).get("title", ""),
+            "goalsList": role_play_data.get("meeting", {}).get("goalsList", [])
+        },
+        "aiCharacter": {
+            "name": role_play_data.get("aiCharacter", {}).get("name", ""),
+            "role": role_play_data.get("aiCharacter", {}).get("role", ""),
+            "details": role_play_data.get("aiCharacter", {}).get("details", "")
+        }
+    }
+
+    template_path = os.path.join(MAIN_SCRIPT_PATH, "templates", "role_play_template.html")
+    with open(template_path, "r", encoding="utf-8") as f:
+        html = f.read()
+        html = html.replace("__data_placeholder__", json.dumps(clean_data))
+        with open(lecture_path, "w", encoding="utf-8") as f:
+            f.write(html)
+
+
 def parse_new(udemy: Udemy, udemy_object: dict):
     total_chapters = udemy_object.get("total_chapters")
     total_lectures = udemy_object.get("total_lectures")
@@ -1789,6 +1932,12 @@ def parse_new(udemy: Udemy, udemy_object: dict):
                 if not dl_quizzes:
                     continue
                 process_quiz(udemy, lecture, chapter_dir)
+                continue
+            
+            if clazz == "role-play":
+                if not dl_quizzes:
+                    continue
+                process_role_play(udemy, lecture, chapter_dir)
                 continue
 
             index = lecture.get("index")  # this is lecture_counter
@@ -2224,7 +2373,7 @@ def main():
                         )
                     else:
                         logger.debug("Lecture: ID is None, skipping")
-                elif clazz == "quiz":
+                elif clazz == "quiz" or clazz == "role-play":
                     lecture_counter += 1
                     lecture_id = entry.get("id")
                     if len(udemy_object["chapters"]) == 0:
@@ -2265,7 +2414,7 @@ def main():
                             }
                         )
                     else:
-                        logger.debug("Quiz: ID is None, skipping")
+                        logger.debug(f"{clazz.capitalize()}: ID is None, skipping")
 
                 udemy_object["chapters"][chapter_index_counter]["lectures"] = lectures
                 udemy_object["chapters"][chapter_index_counter]["lecture_count"] = len(

--- a/templates/role_play_template.html
+++ b/templates/role_play_template.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Role Play</title>
+
+    <style>
+        body {
+            font-family: sf pro text, -apple-system, BlinkMacSystemFont, Roboto, segoe ui, Helvetica, Arial, sans-serif, apple color emoji, segoe ui emoji, segoe ui symbol;
+            font-weight: 400;
+            line-height: 1.6;
+            font-size: 16px;
+            padding: 40px 20px;
+            color: #333;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        p,
+        ul,
+        ol {
+            font-size: 16px;
+            font-weight: 400;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            font-weight: bold;
+        }
+
+        h1 {
+            color: #2c3e50;
+            border-bottom: 2px solid #eaeaea;
+            padding-bottom: 10px;
+
+        }
+
+        h2 {
+            color: #34495e;
+            margin-top: 30px;
+        }
+
+        h3 {
+            color: #2c3e50;
+        }
+
+        ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            max-width: none;
+        }
+
+        .code-snippet {
+            background-color: #fff;
+            border: 1px solid #d1d7dc;
+            color: #b4690e;
+            font-size: 90%;
+            padding: 0.2rem 0.4rem;
+        }
+
+        .code-block {
+            background-color: #fff;
+            color: #b4690e;
+            font-size: 90%;
+        }
+
+        .black-block {
+            color: #000000;
+        }
+
+        .italic-text {
+            font-style: italic;
+        }
+
+        .role {
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 15px;
+            border-left: 5px solid #0056b3;
+        }
+
+        .role.user-role {
+            border-left-color: #28a745;
+        }
+
+        .role-name {
+            font-weight: bold;
+            font-size: 1.2em;
+            color: #0056b3;
+        }
+
+        .user-role .role-name {
+            color: #28a745;
+        }
+
+        .role-title {
+            font-style: italic;
+            color: #666;
+            margin-bottom: 10px;
+        }
+
+        ul.goals-list {
+            padding-left: 20px;
+            list-style: disc;
+        }
+
+        ul.goals-list li {
+            margin-bottom: 8px;
+        }
+    </style>
+</head>
+
+<body onload="main()">
+    <h1 id="rp-title"></h1>
+    <h2 id="rp-meeting-title"></h2>
+
+    <div>
+        <h2>Roles</h2>
+        <div id="rp-roles"></div>
+    </div>
+
+    <div>
+        <h2>Scenario</h2>
+        <div id="rp-scenario"></div>
+    </div>
+
+    <div>
+        <h2>Goals</h2>
+        <ul id="rp-goals" class="goals-list"></ul>
+    </div>
+
+    <script>
+        const rpData = __data_placeholder__;
+
+        function main() {
+            var titleElement = document.getElementById("rp-title");
+            var titleText = rpData.title || "Role Play";
+            titleElement.innerHTML = titleText.replace(/^\d{3}\s*/, "");
+
+            var meetingTitleElement = document.getElementById("rp-meeting-title");
+            if (rpData.meeting && rpData.meeting.title) {
+                meetingTitleElement.innerHTML = rpData.meeting.title;
+            } else {
+                meetingTitleElement.style.display = "none";
+            }
+
+            // render roles
+            var rolesContainer = document.getElementById("rp-roles");
+
+            // AI character
+            if (rpData.aiCharacter) {
+                var aiRoleDiv = document.createElement("div");
+                aiRoleDiv.className = "role";
+
+                var aiRoleName = document.createElement("div");
+                aiRoleName.className = "role-name";
+                aiRoleName.innerHTML = rpData.aiCharacter.name || "";
+
+                var aiRoleTitle = document.createElement("div");
+                aiRoleTitle.className = "role-title";
+                aiRoleTitle.innerHTML = rpData.aiCharacter.role || "";
+
+                var aiRoleDesc = document.createElement("div");
+                aiRoleDesc.innerHTML = rpData.aiCharacter.details || "";
+
+                aiRoleDiv.appendChild(aiRoleName);
+                aiRoleDiv.appendChild(aiRoleTitle);
+                aiRoleDiv.appendChild(aiRoleDesc);
+                rolesContainer.appendChild(aiRoleDiv);
+            }
+
+            // user
+            var userRoleDiv = document.createElement("div");
+            userRoleDiv.className = "role user-role";
+            var userRoleName = document.createElement("div");
+            userRoleName.className = "role-name";
+            userRoleName.innerHTML = "Your Role";  // mask downloader's name
+            var userRoleDesc = document.createElement("div");
+            userRoleDesc.innerHTML = rpData.learnerRole || "";
+            userRoleDiv.appendChild(userRoleName);
+            userRoleDiv.appendChild(userRoleDesc);
+            rolesContainer.appendChild(userRoleDiv);
+
+            // render scenario
+            var scenarioElement = document.getElementById("rp-scenario");
+            scenarioElement.innerHTML = rpData.scenario || "";
+
+            // render goals
+            var goalsList = document.getElementById("rp-goals");
+            if (rpData.meeting && rpData.meeting.goalsList) {
+                for (var i = 0; i < rpData.meeting.goalsList.length; i++) {
+                    var goal = rpData.meeting.goalsList[i];
+                    var li = document.createElement("li");
+                    li.innerHTML = goal.description || "";
+                    goalsList.appendChild(li);
+                }
+            }
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Changes:

- Added new HTML template for role play, based on the coding one but some styling.
- Modified `main.py` and `constants.py` to support parsing the practice assignments.
- Gets both roles, scenario and goals
- Tested with 25 roleplay lectures

It's useful to have for a complete downloads and for correct lecture ordering, as there will be more and more of these. Also people can copy-paste this into LLMs to do their own role play.

